### PR TITLE
Close input stream after parsing JSON snapshot

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlSnapshotParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlSnapshotParser.java
@@ -14,6 +14,7 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -34,6 +35,12 @@ public class YamlSnapshotParser extends YamlParser implements SnapshotParser {
                 parsedYaml = yaml.loadAs(new InputStreamReader(stream, "UTF-8"), Map.class);
             } catch (Exception e) {
                 throw new LiquibaseParseException("Syntax error in " + getSupportedFileExtensions()[0] + ": " + e.getMessage(), e);
+            }
+            finally {
+                try {
+                    stream.close();
+                } catch (IOException ioe) {
+                }
             }
 
             Map rootList = (Map) parsedYaml.get("snapshot");


### PR DESCRIPTION
CORE-2806 If the input stream parsing the snapshot file does not get
closed, then the process cannot delete the snapshot file after it is done
using it