### PR TITLE
DVONE-5036 changed CreateProcedureGenerator.removeTrailingDelimiter t…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
@@ -100,18 +100,14 @@ public class CreateProcedureGenerator extends AbstractSqlGenerator<CreateProcedu
             return procedureText;
         }
 
-        String fixedText = procedureText;
-        while (fixedText.length() > 0) {
-            String lastChar = fixedText.substring(fixedText.length() - 1);
-            if (lastChar.equals(" ") || lastChar.equals("\n") || lastChar.equals("\r") || lastChar.equals("\t")) {
-                fixedText = fixedText.substring(0, fixedText.length() - 1);
-            } else {
-                break;
-            }
-        }
         endDelimiter = endDelimiter.replace("\\r", "\r").replace("\\n", "\n");
-        if (fixedText.endsWith(endDelimiter)) {
-            return fixedText.substring(0, fixedText.length() - endDelimiter.length());
+        // DVONE-5036
+        String endCommentsTrimmedText = StringUtils.stripSqlCommentsAndWhitespacesFromTheEnd(procedureText);
+        // Note: need to trim the delimiter since the return of the above call trims whitespaces, and to match
+        // we have to trim the endDelimiter as well.
+        String trimmedDelimiter = StringUtils.trimRight(endDelimiter);
+        if (endCommentsTrimmedText.endsWith(trimmedDelimiter)) {
+            return endCommentsTrimmedText.substring(0, endCommentsTrimmedText.length() - trimmedDelimiter.length());
         } else {
             return procedureText;
         }

--- a/liquibase-core/src/test/groovy/liquibase/sqlgenerator/core/CreateProcedureGeneratorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/sqlgenerator/core/CreateProcedureGeneratorTest.groovy
@@ -11,18 +11,35 @@ class CreateProcedureGeneratorTest extends Specification {
         CreateProcedureGenerator.removeTrailingDelimiter(text, delimiter) == expected
 
         where:
-        text                               | delimiter | expected
-        null                               | ";"       | null
-        ""                                 | ";"       | ""
-        "null delimiter;"                  | null      | "null delimiter;"
-        "no delimiter"                     | ";"       | "no delimiter"
-        "no delimiter"                     | "\n/"     | "no delimiter"
-        "with delimiter\n/"                | "\n/"     | "with delimiter"
-        "with delimiter\n/\n   \n \n"      | "\n/"     | "with delimiter"
-        "other stuff\n/and more"           | "\n/"     | "other stuff\n/and more"
-        "semicolon delimiter;"             | ";"       | "semicolon delimiter"
-        "semicolon delimiter\n\n;\n\r  \n" | ";"       | "semicolon delimiter\n\n"
-        "mid-semicolon;delimiter"          | ";"       | "mid-semicolon;delimiter"
-        "mid-semicolon;delimiter;"         | ";"       | "mid-semicolon;delimiter"
+        text                                                                                                                                                | delimiter | expected
+        null                                                                                                                                                | ";"       | null
+        ""                                                                                                                                                  | ";"       | ""
+        "null delimiter;"                                                                                                                                   | null      | "null delimiter;"
+        "no delimiter"                                                                                                                                      | ";"       | "no delimiter"
+        "no delimiter"                                                                                                                                      | "\n/"     | "no delimiter"
+        "with delimiter\n/"                                                                                                                                 | "\n/"     | "with delimiter"
+        "with delimiter\n/\n   \n \n"                                                                                                                       | "\n/"     | "with delimiter"
+        "with delimiter\n/\n   \n \n"                                                                                                                       | "/"       | "with delimiter\n"
+        "other stuff\n/and more"                                                                                                                            | "\n/"     | "other stuff\n/and more"
+        "semicolon delimiter;"                                                                                                                              | ";"       | "semicolon delimiter"
+        "semicolon delimiter\n\n;\n\r  \n"                                                                                                                  | ";"       | "semicolon delimiter\n\n"
+        "mid-semicolon;delimiter"                                                                                                                           | ";"       | "mid-semicolon;delimiter"
+        "mid-semicolon;delimiter;"                                                                                                                          | ";"       | "mid-semicolon;delimiter"
+        "no delimiter -- some comments"                                                                                                                     | "/"       | "no delimiter -- some comments"
+        "no delimiter\n -- some comments"                                                                                                                   | "/"       | "no delimiter\n -- some comments"
+        "with delimiter;\n/ \n-- some comments"                                                                                                             | "/"       | "with delimiter;\n"
+        "with delimiter;\n/ \n/** some block comments **/ "                                                                                                 | "/"       | "with delimiter;\n"
+        "with delimiter;\n/ \n/**\n some \nblock comments\n **/ "                                                                                           | "/"       | "with delimiter;\n"
+        // no delimiter
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment"                                                   | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;"                                                                 | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment\n/*****another\nblock\n***/"                       | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment\n/*****another\nblock\n***/"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\t--last comment\n\n\n\t--another\n/*****another\nblock\n***/"    | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\t--last comment\n\n\n\t--another\n/*****another\nblock\n***/"
+        // with delimiter
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n/"                                                              | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n/--last comment"                                                | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n/\n--last comment\n/*****another\nblock\n***/"                  | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n/\t--last comment\n\n\n\t--another\n/*****another\nblock\n***/" | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n"
+
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/util/StringUtilsTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/StringUtilsTest.groovy
@@ -150,4 +150,26 @@ class StringUtilsTest extends Specification {
         "abc "  | 5   | "  abc"
         " abc"  | 5   | "  abc"
     }
+
+    @Unroll
+    def "stripSqlCommentsFromTheEnd"() {
+        expect:
+        StringUtils.stripSqlCommentsAndWhitespacesFromTheEnd(input) == output
+
+        where:
+        input                                                                                                                                            | output
+        null                                                                                                                                             | null
+        ""                                                                                                                                               | ""
+        "   "                                                                                                                                            | ""
+        "no comments"                                                                                                                                    | "no comments"
+        "-- some comments"                                                                                                                               | ""
+        "   -- some comments   "                                                                                                                         | ""
+        "create table mtable; --some line comments"                                                                                                      | "create table mtable;"
+        "some txt; \n-- line cmt \n--another "                                                                                                           | "some txt;"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */"                                                                                      | "some txt;"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment"                                                | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment\n/*****another\nblock\n***/"                    | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\t--last comment\n\n\n\t--another\n/*****another\nblock\n***/" | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;"
+
+    }
 }


### PR DESCRIPTION
…o remove the end delimiter string, if any, from the text along with the comments (line and block) and whitespaces following them. The text will be returned as it is if the end delimiter is not found.