### PR TITLE
Added timeout support for ExecuteShellCommandChange

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
@@ -28,6 +28,9 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Executes a given shell executable.
@@ -41,6 +44,11 @@ public class ExecuteShellCommandChange extends AbstractChange {
     private List<String> os;
     private List<String> args = new ArrayList<String>();
     protected List<String> finalCommandArray;
+    private String timeout;
+    private static final Pattern TIMEOUT_PATTERN = Pattern.compile("^\\s*(\\d+)\\s*([sSmMhH]?)\\s*$");
+    private static final Long SECS_IN_MILLIS = 1000L;
+    private static final Long MIN_IN_MILLIS = SECS_IN_MILLIS * 60;
+    private static final Long HOUR_IN_MILLIS = MIN_IN_MILLIS * 60;
 
     @Override
     public boolean generateStatementsVolatile(Database database) {
@@ -73,6 +81,15 @@ public class ExecuteShellCommandChange extends AbstractChange {
         this.os = StringUtils.splitAndTrim(os, ",");
     }
 
+    @DatabaseChangeProperty(description = "Timeout value for executable to run", exampleValue = "10s")
+    public String getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(String timeout) {
+        this.timeout = timeout;
+    }
+
     @DatabaseChangeProperty(description = "List of operating systems on which to execute the command (taken from the os.name Java system property)", exampleValue = "Windows 7")
     public List<String> getOs() {
         return os;
@@ -80,7 +97,16 @@ public class ExecuteShellCommandChange extends AbstractChange {
 
     @Override
     public ValidationErrors validate(Database database) {
-        return new ValidationErrors();
+        ValidationErrors validationErrors = new ValidationErrors();
+        if (!StringUtils.isEmpty(timeout)) {
+            // check for the timeout values, accept only positive value with one letter unit (s/m/h)
+            Matcher matcher = TIMEOUT_PATTERN.matcher(timeout);
+            if (!matcher.matches()) {
+                validationErrors.addError("Invalid value specified for timeout: " + timeout);
+            }
+        }
+
+        return validationErrors;
     }
 
 
@@ -118,9 +144,9 @@ public class ExecuteShellCommandChange extends AbstractChange {
                 public Sql[] generate(Database database) {
 
                     try {
-                      executeCommand(database);
+                        executeCommand(database);
                     } catch (Exception e) {
-                      throw new UnexpectedLiquibaseException("Error executing command: " + e.getLocalizedMessage(), e);
+                        throw new UnexpectedLiquibaseException("Error executing command: " + e.getLocalizedMessage(), e);
                     }
 
                     return null;
@@ -167,7 +193,19 @@ public class ExecuteShellCommandChange extends AbstractChange {
             errorGobbler.start();
             outputGobbler.start();
 
-            returnCode = p.waitFor();
+            // check if timeout is specified
+            if (StringUtils.isEmpty(timeout)) {
+                returnCode = p.waitFor();
+            } else {
+                // can't use Process's new api with timeout, so just workaround it for now
+                long timeoutInMillis = getTimeoutInMillis();
+                if (timeoutInMillis > 0) {
+                    returnCode = waitForOrKill(p, timeoutInMillis);
+                } else {
+                    // do default behavior for any value less than 0
+                    returnCode = p.waitFor();
+                }
+            }
 
             errorGobbler.finish();
             outputGobbler.finish();
@@ -179,12 +217,82 @@ public class ExecuteShellCommandChange extends AbstractChange {
         String errorStreamOut = errorStream.toString(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
         String infoStreamOut = inputStream.toString(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
 
-        if (errorStreamOut != null && ! errorStreamOut.isEmpty()) {
+        if (errorStreamOut != null && !errorStreamOut.isEmpty()) {
             LogFactory.getLogger().severe(errorStreamOut);
         }
         LogFactory.getLogger().info(infoStreamOut);
 
         processResult(returnCode, errorStreamOut, infoStreamOut, database);
+    }
+
+    /**
+     * Waits for the process to complete and kills it if the process is not finished after the specified <code>timeoutInMillis</code>
+     *
+     * @param process
+     * @param timeoutInMillis
+     */
+    private int waitForOrKill(final Process process, long timeoutInMillis) throws ExecutionException, TimeoutException {
+        Integer ret = null;
+        FutureTask<Integer> waitForFinishTask = waitForInDifferentThread(process);
+        try {
+            ret = waitForFinishTask.get(timeoutInMillis, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ignore) {
+            // just loop again and try to get the value
+        } catch (ExecutionException e) {
+            // oops! something wrong, lets throw it back
+            throw e;
+        } catch (TimeoutException e) {
+            // timed out, bail out
+            process.destroy();
+            throw new TimeoutException("Process timed out (" + timeout + ")");
+        }
+
+        return ret;
+    }
+
+    private FutureTask<Integer> waitForInDifferentThread(final Process process) {
+        return new FutureTask<Integer>(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return process.waitFor();
+            }
+        });
+    }
+
+    /**
+     * @return the timeout value in millisecond
+     */
+    private long getTimeoutInMillis() {
+        if (timeout != null) {
+            //Matcher matcher = TIMEOUT_PATTERN.matcher("10s");
+            Matcher matcher = TIMEOUT_PATTERN.matcher(timeout);
+            if (matcher.find()) {
+                String val = matcher.group(1);
+                try {
+                    long valLong = Long.parseLong(val);
+                    String unit = matcher.group(2);
+                    if (StringUtils.isEmpty(unit)) {
+                        return valLong * SECS_IN_MILLIS;
+                    }
+                    char u = unit.toLowerCase().charAt(0);
+                    // only s/m/h possible here
+                    switch (u) {
+                        case 'h':
+                            valLong = valLong * HOUR_IN_MILLIS;
+                            break;
+                        case 'm':
+                            valLong = valLong * MIN_IN_MILLIS;
+                        default:
+                            valLong = valLong * SECS_IN_MILLIS;
+                    }
+
+                    return valLong;
+                } catch (NumberFormatException ignore) {
+                }
+
+            }
+        }
+        return 0;
     }
 
     /**
@@ -233,7 +341,7 @@ public class ExecuteShellCommandChange extends AbstractChange {
             List<String> os = StringUtils.splitAndTrim(StringUtils.trimToEmpty(parsedNode.getChildValue(null, "os", String.class)), ",");
             if (os.size() == 1 && os.get(0).equals("")) {
                 this.os = null;
-            } else  if (os.size() > 0) {
+            } else if (os.size() > 0) {
                 this.os = os;
             }
         }
@@ -278,9 +386,9 @@ public class ExecuteShellCommandChange extends AbstractChange {
         }
 
     }
-    
+
     @Override
     public String toString() {
-      return "external process '" + getExecutable() + "' " + getArgs(); 
+        return "external process '" + getExecutable() + "' " + getArgs();
     }
 }

--- a/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
@@ -240,7 +240,8 @@ public class ExecuteShellCommandChange extends AbstractChange {
         } catch (TimeoutException e) {
             // timed out, bail out
             process.destroy();
-            throw new TimeoutException("Process timed out (" + timeout + ")");
+            String timeoutStr = timeout != null ? timeout : timeoutInMillis + " ms";
+            throw new TimeoutException("Process timed out (" + timeoutStr + ")");
         }
 
         return ret;

--- a/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
@@ -194,17 +194,13 @@ public class ExecuteShellCommandChange extends AbstractChange {
             outputGobbler.start();
 
             // check if timeout is specified
-            if (StringUtils.isEmpty(timeout)) {
-                returnCode = p.waitFor();
+            // can't use Process's new api with timeout, so just workaround it for now
+            long timeoutInMillis = getTimeoutInMillis();
+            if (timeoutInMillis > 0) {
+                returnCode = waitForOrKill(p, timeoutInMillis);
             } else {
-                // can't use Process's new api with timeout, so just workaround it for now
-                long timeoutInMillis = getTimeoutInMillis();
-                if (timeoutInMillis > 0) {
-                    returnCode = waitForOrKill(p, timeoutInMillis);
-                } else {
-                    // do default behavior for any value less than 0
-                    returnCode = p.waitFor();
-                }
+                // do default behavior for any value equal to or less than 0
+                returnCode = p.waitFor();
             }
 
             errorGobbler.finish();
@@ -262,7 +258,7 @@ public class ExecuteShellCommandChange extends AbstractChange {
     /**
      * @return the timeout value in millisecond
      */
-    private long getTimeoutInMillis() {
+    protected long getTimeoutInMillis() {
         if (timeout != null) {
             //Matcher matcher = TIMEOUT_PATTERN.matcher("10s");
             Matcher matcher = TIMEOUT_PATTERN.matcher(timeout);

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
@@ -1051,6 +1051,7 @@
 			</xsd:sequence>
 			<xsd:attribute name="executable" type="xsd:string" use="required" />
 			<xsd:attribute name="os" type="xsd:string" />
+			<xsd:attribute name="timeout" type="xsd:string" />
 		</xsd:complexType>
 	</xsd:element>
 

--- a/liquibase-core/src/test/groovy/liquibase/change/core/ExecuteShellCommandChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/ExecuteShellCommandChangeTest.groovy
@@ -53,4 +53,25 @@ class ExecuteShellCommandChangeTest extends Specification {
         that change.getOs(), Matchers.contains(["linux", "mac"].toArray())
         that change.args, Matchers.contains("-out", "-test")
     }
+
+    def "test getTimoutInMillis"() {
+        when:
+        def change = new ExecuteShellCommandChange()
+        try {
+            change.load(new liquibase.parser.core.ParsedNode(null, "executeCommand")
+                    .addChildren([executable: "/usr/bin/test", os: "linux,mac", timeout:"10s"])
+                    .addChild(new liquibase.parser.core.ParsedNode(null, "args")
+                    .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-out"))
+                    .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-test"))
+            ), resourceSupplier.simpleResourceAccessor)
+        } catch (ParsedNodeException e) {
+            e.printStackTrace()
+        }
+
+        then:
+        change.executable == "/usr/bin/test"
+        change.timeout == "10s"
+        that change.getOs(), Matchers.contains(["linux", "mac"].toArray())
+        that change.args, Matchers.contains("-out", "-test")
+    }
 }


### PR DESCRIPTION
Timeout value can be specified with value followed by a single letter for second (s), minute (m) or hour (h). Example: timeout="10s", timeout=" 10 m" or timeout="10H". The process will be destroyed with process.destroy() if it does not return the before the specified time.