### PR TITLE
DAT-1444: Expose ability to override ServiceLocator logger

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -103,7 +103,10 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
 
         Table changeLogTable = null;
         try {
-            changeLogTable = SnapshotGeneratorFactory.getInstance().getDatabaseChangeLogTable(new SnapshotControl(database, false, Table.class, Column.class), database);
+            SnapshotGeneratorFactory factory = SnapshotGeneratorFactory.getInstance();
+            LogFactory.getInstance().getLog().debug("SnapshotGeneratorFactory initialization completed");
+            changeLogTable = factory.getDatabaseChangeLogTable(new SnapshotControl(database, false, Table.class, Column.class), database);
+            LogFactory.getInstance().getLog().debug("DATABASECHANGELOG snapshot completed");
         } catch (LiquibaseException e) {
             throw new UnexpectedLiquibaseException(e);
         }

--- a/liquibase-core/src/main/java/liquibase/servicelocator/ServiceLocator.java
+++ b/liquibase-core/src/main/java/liquibase/servicelocator/ServiceLocator.java
@@ -254,4 +254,11 @@ public class ServiceLocator {
     protected Logger getLogger() {
         return logger;
     }
+
+    /** Expose ability to override {@link DefaultLogger} after {@link ServiceLocator} initialization */
+    public void setLogger(Logger logger) {
+        if (this.logger instanceof DefaultLogger) {
+            this.logger = logger;
+        }
+    }
 }


### PR DESCRIPTION
Because `ServiceLocator` is initialized in static block it uses DefaultLogger which prints all messages in console.
Probably because its OSGi setup we loose console (`System.out` gets reassigend) output.
Added ability to hook Datical logger.
Can be done in more 'straightforward' manner, but:
\- was done this way to be 100% sure that nobody who's using Liquibase will be affected
\- considering this as temp code that may be removed in future