### PR TITLE
DAT-1546: Trim extra spaces for Label/Context expressions

### DIFF
--- a/liquibase-core/src/main/java/liquibase/ContextExpression.java
+++ b/liquibase-core/src/main/java/liquibase/ContextExpression.java
@@ -90,6 +90,7 @@ public class ContextExpression {
     }
 
     private boolean matches(String expression, Contexts runtimeContexts) {
+        expression = StringUtils.trimToEmpty(expression);
         if (runtimeContexts.isEmpty()) {
             return true;
         }
@@ -138,7 +139,7 @@ public class ContextExpression {
         boolean notExpression = false;
         if (expression.startsWith("!")) {
             notExpression = true;
-            expression = expression.substring(1);
+            expression = expression.substring(1).trim();
         }
 
         for (String context : runtimeContexts.getContexts()) {
@@ -155,8 +156,6 @@ public class ContextExpression {
         } else {
             return false;
         }
-
-
     }
 
     public boolean isEmpty() {

--- a/liquibase-core/src/main/java/liquibase/ContextExpression.java
+++ b/liquibase-core/src/main/java/liquibase/ContextExpression.java
@@ -1,12 +1,9 @@
 package liquibase;
 
-import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.util.ExpressionMatcher;
 import liquibase.util.StringUtils;
 
-import java.text.ParseException;
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Encapsulates logic for evaluating if a set of runtime contexts matches a context expression string.
@@ -90,72 +87,7 @@ public class ContextExpression {
     }
 
     private boolean matches(String expression, Contexts runtimeContexts) {
-        expression = StringUtils.trimToEmpty(expression);
-        if (runtimeContexts.isEmpty()) {
-            return true;
-        }
-
-        if (expression.trim().equals(":TRUE")) {
-            return true;
-        }
-        if (expression.trim().equals(":FALSE")) {
-            return false;
-        }
-
-        while (expression.contains("(")) {
-            Pattern pattern = Pattern.compile("(.*?)\\((.*?)\\)(.*)");
-            Matcher matcher = pattern.matcher(expression);
-            if (!matcher.matches()) {
-                throw new UnexpectedLiquibaseException("Cannot parse context pattern "+expression);
-            }
-            String parenExpression = matcher.group(2);
-
-            parenExpression = ":"+String.valueOf(matches(parenExpression, runtimeContexts)).toUpperCase();
-
-            expression = matcher.group(1)+" "+parenExpression+" "+matcher.group(3);
-        }
-
-        String[] orSplit = expression.split("\\s+or\\s+");
-        if (orSplit.length > 1) {
-            for (String split : orSplit) {
-                if (matches(split, runtimeContexts)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        String[] andSplit = expression.split("\\s+and\\s+");
-        if (andSplit.length > 1) {
-            for (String split : andSplit) {
-                if (!matches(split, runtimeContexts)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-
-        boolean notExpression = false;
-        if (expression.startsWith("!")) {
-            notExpression = true;
-            expression = expression.substring(1).trim();
-        }
-
-        for (String context : runtimeContexts.getContexts()) {
-            if (context.equalsIgnoreCase(expression)) {
-                if (notExpression) {
-                    return false;
-                } else {
-                    return true;
-                }
-            }
-        }
-        if (notExpression) {
-            return true;
-        } else {
-            return false;
-        }
+        return ExpressionMatcher.matches(expression, runtimeContexts.getContexts());
     }
 
     public boolean isEmpty() {

--- a/liquibase-core/src/main/java/liquibase/LabelExpression.java
+++ b/liquibase-core/src/main/java/liquibase/LabelExpression.java
@@ -1,11 +1,9 @@
 package liquibase;
 
-import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.util.ExpressionMatcher;
 import liquibase.util.StringUtils;
 
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class LabelExpression {
 
@@ -115,74 +113,7 @@ public class LabelExpression {
     }
 
     private boolean matches(String expression, Labels runtimeLabels) {
-        expression = StringUtils.trimToEmpty(expression);
-        if (runtimeLabels.isEmpty()) {
-            return true;
-        }
-
-        if (expression.trim().equals(":TRUE")) {
-            return true;
-        }
-        if (expression.trim().equals(":FALSE")) {
-            return false;
-        }
-
-        while (expression.contains("(")) {
-            Pattern pattern = Pattern.compile("(.*?)\\(([^\\(\\)]*?)\\)(.*)");
-            Matcher matcher = pattern.matcher(expression);
-            if (!matcher.matches()) {
-                throw new UnexpectedLiquibaseException("Cannot parse label pattern "+expression);
-            }
-            String parenExpression = matcher.group(2);
-
-            parenExpression = ":"+String.valueOf(matches(parenExpression, runtimeLabels)).toUpperCase();
-
-            expression = matcher.group(1)+" "+parenExpression+" "+matcher.group(3);
-        }
-
-        String[] orSplit = expression.split("\\s+or\\s+");
-        if (orSplit.length > 1) {
-            for (String split : orSplit) {
-                if (matches(split, runtimeLabels)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        String[] andSplit = expression.split("\\s+and\\s+");
-        if (andSplit.length > 1) {
-            for (String split : andSplit) {
-                if (!matches(split, runtimeLabels)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-
-        boolean notExpression = false;
-        if (expression.startsWith("!")) {
-            notExpression = true;
-            expression = expression.substring(1).trim();
-        } else if (expression.toLowerCase().startsWith("not ")) {
-            notExpression = true;
-            expression = expression.substring(4).trim();
-        }
-
-        if (expression.trim().equals(":TRUE")) {
-            return !notExpression;
-        }
-        if (expression.trim().equals(":FALSE")) {
-            return notExpression;
-        }
-
-        for (String label : runtimeLabels.getLabels()) {
-            if (label.equalsIgnoreCase(expression)) {
-                return !notExpression;
-            }
-        }
-        return notExpression;
+        return ExpressionMatcher.matches(expression, runtimeLabels.getLabels());
     }
 
     public boolean isEmpty() {

--- a/liquibase-core/src/main/java/liquibase/LabelExpression.java
+++ b/liquibase-core/src/main/java/liquibase/LabelExpression.java
@@ -115,6 +115,7 @@ public class LabelExpression {
     }
 
     private boolean matches(String expression, Labels runtimeLabels) {
+        expression = StringUtils.trimToEmpty(expression);
         if (runtimeLabels.isEmpty()) {
             return true;
         }
@@ -163,10 +164,10 @@ public class LabelExpression {
         boolean notExpression = false;
         if (expression.startsWith("!")) {
             notExpression = true;
-            expression = expression.substring(1);
+            expression = expression.substring(1).trim();
         } else if (expression.toLowerCase().startsWith("not ")) {
             notExpression = true;
-            expression = expression.substring(4);
+            expression = expression.substring(4).trim();
         }
 
         if (expression.trim().equals(":TRUE")) {
@@ -182,8 +183,6 @@ public class LabelExpression {
             }
         }
         return notExpression;
-
-
     }
 
     public boolean isEmpty() {

--- a/liquibase-core/src/main/java/liquibase/util/ExpressionMatcher.java
+++ b/liquibase-core/src/main/java/liquibase/util/ExpressionMatcher.java
@@ -1,0 +1,111 @@
+package liquibase.util;
+
+import liquibase.exception.UnexpectedLiquibaseException;
+
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Common functionality for matching set of Context/Labels against provided expression.
+ * Supported syntax:
+ * - ! / not - to negate expression/token
+ * - and - conjunction operator
+ * - or - disjunction operator
+ * - () - increase evaluation order priority for sub-expression
+ *
+ * Examples:
+ * "(a and b) or (c and d)"
+ * "!a and b"
+ *
+ * Usage:
+ * @see liquibase.LabelExpression
+ * @see liquibase.ContextExpression
+ */
+public final class ExpressionMatcher {
+
+    /** find "(nested_expression)" in "left and (nested_expression) or right" expression */
+    private static final Pattern NESTED_EXPRESSION_PATTERN = Pattern.compile("\\([^()]+\\)");
+
+    private ExpressionMatcher() {
+        throw new AssertionError("Utility class. Not designed for instantiation");
+    }
+
+    /**
+     * Test provided {@code expression} against list of {@code items}.
+     * Case insensitive.
+     *
+     * @param expression - expression that will be parsed and evaluated against provided list of items
+     * @param items - list of items
+     * @return {@code true} if provided list of items satisfy expression criteria. {@code false} otherwise.
+     */
+    public static boolean matches(String expression, Collection<String> items) {
+        expression = StringUtils.trimToEmpty(expression);
+        if (items.isEmpty()) {
+            return true;
+        }
+
+        if (expression.equals(":TRUE")) {
+            return true;
+        }
+        if (expression.equals(":FALSE")) {
+            return false;
+        }
+
+        while (expression.contains("(")) {
+            Matcher matcher = NESTED_EXPRESSION_PATTERN.matcher(expression);
+            if (!matcher.find()) {
+                throw new UnexpectedLiquibaseException("Cannot parse expression " + expression);
+            }
+
+            String left = expression.substring(0, matcher.start());
+            String right = expression.substring(matcher.end());
+            String nestedExpression = expression.substring(matcher.start() + 1, matcher.end() - 1); // +1/-1 -- exclude captured parenthesis
+
+            expression = left + " :" + String.valueOf(matches(nestedExpression, items)).toUpperCase() + " " + right;
+        }
+
+        String[] orSplit = expression.split("\\s+or\\s+");
+        if (orSplit.length > 1) {
+            for (String split : orSplit) {
+                if (matches(split, items)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        String[] andSplit = expression.split("\\s+and\\s+");
+        if (andSplit.length > 1) {
+            for (String split : andSplit) {
+                if (!matches(split, items)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        boolean notExpression = false;
+        if (expression.startsWith("!")) {
+            notExpression = true;
+            expression = expression.substring(1).trim();
+        } else if (expression.toLowerCase().startsWith("not ")) {
+            notExpression = true;
+            expression = expression.substring(4).trim();
+        }
+
+        if (expression.trim().equals(":TRUE")) {
+            return !notExpression;
+        }
+        if (expression.trim().equals(":FALSE")) {
+            return notExpression;
+        }
+
+        for (String item : items) {
+            if (item.equalsIgnoreCase(expression)) {
+                return !notExpression;
+            }
+        }
+        return notExpression;
+    }
+}

--- a/liquibase-core/src/test/groovy/liquibase/ContextExpressionTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/ContextExpressionTest.groovy
@@ -170,6 +170,24 @@ class ContextExpressionTest extends Specification {
         "a and b or c, d" | "e"             | false
     }
 
+    @Unroll("#featureName: testContexts '#testContexts' against: '#controlContexts'")
+    def "trim extra spaces"() {
+        expect:
+        assert new ContextExpression(testContexts).matches(new Contexts('a, b')) == new ContextExpression(controlContexts).matches(new Contexts('a, b'))
+        assert new ContextExpression(testContexts).matches(new Contexts('c'))    == new ContextExpression(controlContexts).matches(new Contexts('c'))
+
+        where:
+        testContexts                    | controlContexts
+        "   a  "                        | "a"
+        " ! a  "                        | "!a"
+        " a  and  b "                   | "a and b"
+        " ( a  and  b ) or ! c "        | "(a and b) or !c"
+        " a  and  b "                   | "a and b"
+        "a    and    b   or   c"        | "a and b or c"
+        " (a and  b ) or ( c and  d)"   | "(a and b) or (c and d)"
+        "! (a and  b ) or ( ! c and  d)"| "!(a and b) or (!c and d)"
+    }
+
     @Unroll
     def isEmpty() {
         expect:

--- a/liquibase-core/src/test/groovy/liquibase/LabelExpressionTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/LabelExpressionTest.groovy
@@ -178,6 +178,28 @@ class LabelExpressionTest extends Specification {
         "a and b or c, d" | "e"           | false
     }
 
+    @Unroll("#featureName: testLabels '#testLabels' against: '#controlLabels'")
+    def "trim extra spaces"() {
+        expect:
+        assert new LabelExpression(testLabels).matches(new Labels('a, b')) == new LabelExpression(controlLabels).matches(new Labels('a, b'))
+        assert new LabelExpression(testLabels).matches(new Labels('c'))    == new LabelExpression(controlLabels).matches(new Labels('c'))
+
+        where:
+        testLabels                      | controlLabels
+        "   a  "                        | "a"
+        " ! a  "                        | "not a"
+        " ! ( a )  "                    | "!a"
+        " ! ( ! a )  "                  | "a"
+        " not ( !a )  "                 | "a"
+        " a  and  b "                   | "a and b"
+        " ( (a )  and  ( b) ) "         | "a and b"
+        " ( a  and  b ) or ! c "        | "(a and b) or !c"
+        " a  and  b "                   | "a and b"
+        "a    and    b   or   c"        | "a and b or c"
+        " (a and  b ) or ( c and  d)"   | "(a and b) or (c and d)"
+        "! (a and  b ) or ( ! c and  d)"| "!(a and b) or (!c and d)"
+    }
+
     @Unroll
     def isEmpty() {
         expect:


### PR DESCRIPTION
@nvoxland 
doing copy-paste of tests for Label/Context expressions noticed that there are few differences.
because code/logic is mostly the same, I don't understand if its bug or intended behavior (if there is reason behind this diff)

cases that will work for Lables, but fail for Contexts:
\- `!(a)` will not behave as `!a` (or more complex case `!(!a)` is not the same as `a`)
basically due to error that `:TRUE/:FALSE` string being evaluated against context value (missing second check after normalized expression was constructed due to recursive call)

\- some kinds of nested expressions will fail to parse (match against pattern), like `' ( (a )  and  ( b) ) '`, due to diff in regex.
```
for Context: (.*?)\\((.*?)\\)(.*)
for Labels: (.*?)\\(([^\\(\\)]*?)\\)(.*)
```