### PR TITLE
DAT-2424: Postgres function-base index support

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -77,6 +77,13 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
             }
 
             example.setAttribute(LIQUIBASE_COMPLETE, null);
+
+            // computed Postgres columns for indexes are mishandled
+            if (column == null && snapshot.getDatabase() instanceof PostgresDatabase) {
+                ((Column) example).setComputed(true);
+                return example;
+            }
+
             return column;
         } catch (Exception e) {
             throw new DatabaseException(e);

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -47,9 +47,6 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
         Relation relation = ((Column) example).getRelation();
         if (((Column) example).getComputed() != null && ((Column) example).getComputed()) {
             return example;
-        } else if (database instanceof PostgresDatabase && looksLikeFunction(example.getName())) {
-            ((Column) example).setComputed(true);
-            return example;
         }
 
         Schema schema = relation.getSchema();
@@ -82,6 +79,12 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
             }
 
             example.setAttribute(LIQUIBASE_COMPLETE, null);
+
+            if (column == null && database instanceof PostgresDatabase && looksLikeFunction(example.getName())) {
+                ((Column) example).setComputed(true);
+                return example;
+            }
+
             return column;
         } catch (Exception e) {
             throw new DatabaseException(e);

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -35,7 +35,6 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
 
     private Pattern postgresStringValuePattern = Pattern.compile("'(.*)'::[\\w ]+");
     private Pattern postgresNumberValuePattern = Pattern.compile("(\\d*)::[\\w ]+");
-    private Pattern postgresFunctionRefPattern = Pattern.compile("\\([^)]+\\)"); // something inside brackets: (...)
 
     public ColumnSnapshotGenerator() {
         super(Column.class, new Class[]{Table.class, View.class});
@@ -543,7 +542,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
      * - (name)::text || '- concatenation example'
      */
     private boolean looksLikeFunction(String columnName) {
-        return postgresFunctionRefPattern.matcher(columnName).find();
+        return columnName.contains("(");
     }
 
     //START CODE FROM SQLITEDatabaseSnapshotGenerator


### PR DESCRIPTION
so problem is that we ignore column generated by statement
`create index function_based_idx on my_table(lower(name));`

root cause: for Postgres, during IndexSnapshotGenerator, we can't mark this column as computed because `lower(name)` part will be returned as COLUMN_NAME (and not FILTER_CONDITION)

```
"TABLE_CAT" -> "null"
"TABLE_SCHEM" -> "src_schema"
"TABLE_NAME" -> "my_table"
"NON_UNIQUE" -> "true"
"INDEX_QUALIFIER" -> "null"
"INDEX_NAME" -> "function_based_idx"
"TYPE" -> "3"
"ORDINAL_POSITION" -> "1"
"COLUMN_NAME" -> "lower((name)::text)"
"ASC_OR_DESC" -> "A"
"CARDINALITY" -> "0.0"
"PAGES" -> "1"
"FILTER_CONDITION" -> "null"
```

and there is no alternative reliable field that we can decide if this column is computed.

I don't like this implementation and afraid of possible side-effects, but the only alternatives that I see:
\- don't rely on drivers **databaseMetaData** `getIndexInfo` and write custom query
\- make additional auxiliary query that will give us which column is 'derived from expression'.

what do you think?