### PR TITLE
DAT-2472: Fixed DependencyGraph recursive depth check

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/DependencyUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/DependencyUtil.java
@@ -13,7 +13,7 @@ public class DependencyUtil {
         private NodeValueListener<T> listener;
         private List<GraphNode<T>> evaluatedNodes = new ArrayList<GraphNode<T>>();
 
-        private int recursiveSizeCheck = -1;
+        private Integer recursiveSizeCheck;
 
         public DependencyGraph(NodeValueListener<T> listener) {
             this.listener = listener;
@@ -82,13 +82,14 @@ public class DependencyUtil {
                 }
             }
             if (nextNodesToDisplay != null && nextNodesToDisplay.size() > 0) {
-                if (nextNodesToDisplay.size() == recursiveSizeCheck) {
+                int recursiveSizeDepth = recursiveSizeDepth(nextNodesToDisplay);
+                if (recursiveSizeDepth < 0 || (recursiveSizeCheck != null && recursiveSizeDepth >= recursiveSizeCheck)) {
                     //Recursion is not making progress, heading to a stack overflow exception.
                     //Probably some cycles in there somewhere, so pull out a node and re-try
-                    GraphNode nodeToRemove = null;
+                    GraphNode<T> nodeToRemove = null;
                     int nodeToRemoveLinks = Integer.MAX_VALUE;
-                    for (GraphNode node : nextNodesToDisplay) {
-                        List links = node.getComingInNodes();
+                    for (GraphNode<T> node : nextNodesToDisplay) {
+                        List<GraphNode<T>> links = node.getComingInNodes();
                         if (links != null && links.size() < nodeToRemoveLinks) {
                             nodeToRemove = node;
                             nodeToRemoveLinks = links.size();
@@ -98,10 +99,49 @@ public class DependencyUtil {
                     nextNodesToDisplay.remove(nodeToRemove);
                 }
 
-                recursiveSizeCheck = nextNodesToDisplay.size();
+                if (recursiveSizeDepth >= 0) {
+                    recursiveSizeCheck = recursiveSizeDepth;
+                }
                 computeDependencies(nextNodesToDisplay);
             }
             // here the recursive call ends
+        }
+
+        private int recursiveSizeDepth(List<GraphNode<T>> nodes) {
+            if (nodes == null) {
+                return 0;
+            }
+            int sum = 0;
+            for (GraphNode<T> node : nodes) {
+                int depth = recursiveSizeDepth(node, 0);
+                if (depth < 0) {
+                    // safety counter was triggered. terminate
+                    return -1;
+                }
+                sum += depth;
+            }
+            return sum;
+        }
+
+        private int recursiveSizeDepth(GraphNode<T> node, int safetyCounter) {
+            if (safetyCounter > 1000) {
+                return -1;
+            }
+            if (isAlreadyEvaluated(node)) {
+                return 0;
+            } else if (node.getGoingOutNodes() == null || node.getGoingOutNodes().isEmpty()) { // leaf node
+                return 1;
+            }
+            int sum = 0;
+            safetyCounter++;
+            for (GraphNode<T> n : node.getGoingOutNodes()) {
+                int depth = recursiveSizeDepth(n, safetyCounter);
+                if (depth < 0) {
+                    return -1;
+                }
+                sum += depth;
+            }
+            return node.getGoingOutNodes().size() + sum;
         }
 
         private boolean isAlreadyEvaluated(GraphNode<T> node) {

--- a/liquibase-core/src/test/java/liquibase/util/DependencyUtilTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/DependencyUtilTest.java
@@ -1,0 +1,127 @@
+package liquibase.util;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.*;
+
+import java.util.*;
+
+import liquibase.util.DependencyUtil.*;
+
+
+public class DependencyUtilTest {
+
+    private DependencyGraph<String> graph;
+    private List<String> dependencyOrder = new ArrayList<String>();
+
+    @Before
+    public void setup() {
+        dependencyOrder.clear();
+        NodeValueListener<String> listener = new NodeValueListener<String>() {
+            @Override public void evaluating(String nodeValue) {
+                dependencyOrder.add(nodeValue);
+            }
+        };
+
+        graph = new DependencyUtil.DependencyGraph<String>(listener);
+
+    }
+
+    @Test
+    public void testBaseCase() {
+        // a > b > c > d > e
+        graph.add("a", "b");
+        graph.add("b", "c");
+        graph.add("c", "d");
+        graph.add("d", "e");
+        graph.computeDependencies();
+        List<String> expected = Arrays.asList("a", "b", "c", "d", "e");
+        Assert.assertEquals(expected, dependencyOrder);
+    }
+
+    @Test
+    public void testBranchingCase() {
+        // a > b > c1
+        //       > c2 > d
+        graph.add("a", "b");
+        graph.add("b", "c1");
+        graph.add("b", "c2");
+        graph.add("c2", "d");
+        graph.computeDependencies();
+        List<String> expected = Arrays.asList("a", "b", "c1", "c2", "d");
+        Assert.assertEquals(expected, dependencyOrder);
+    }
+
+    @Test
+    public void testIndependentBranchesCase() {
+        // a > b > c1
+        //       > c2
+        // o > p1 > r1 > s
+        //     p2 > r2 > s2
+        //             > s3
+        // x > y
+        graph.add("a", "b");
+        graph.add("b", "c1");
+        graph.add("b", "c2");
+        graph.add("o", "p1");
+        graph.add("p1", "r1");
+        graph.add("r1", "s");
+        graph.add("o", "p2");
+        graph.add("p2", "r2");
+        graph.add("r2", "s2");
+        graph.add("r2", "s3");
+        graph.add("x", "y");
+        graph.computeDependencies();
+        List<String> expected = Arrays.asList(
+                "a", "o", "x",          // level 1
+                "b", "p1", "p2", "y",   // level 2
+                "c1", "c2", "r1", "r2", // level 3
+                "s", "s2", "s3");       // roof
+        Assert.assertEquals(expected, dependencyOrder);
+    }
+
+    /* negative load */
+
+    @Test(timeout = 3000)
+    public void recursionSafetyCheck_edgeCase() {
+        graph.add("a", "a");
+        graph.computeDependencies();
+        // assert test executes in less than 3 seconds
+    }
+
+    @Test(timeout = 3000)
+    public void recursionSafetyCheck() {
+        // a > B > c > d > B
+        graph.add("a", "B");
+        graph.add("B", "c");
+        graph.add("c", "d");
+        graph.add("d", "B");
+        graph.computeDependencies();
+        Assert.assertThat(dependencyOrder, CoreMatchers.hasItem("a")); // we try to capture something
+    }
+
+    @Test(timeout = 3000)
+    public void recursionSafetyCheck2() {
+        //     a > B > c > d
+        // m > k > B
+        // d > m (both have B in common)
+        graph.add("a", "B");
+        graph.add("B", "c");
+        graph.add("c", "d");
+        graph.add("m", "k");
+        graph.add("k", "B");
+        graph.add("d", "m");
+        graph.computeDependencies();
+        Assert.assertThat(dependencyOrder, CoreMatchers.hasItem("a"));
+    }
+
+    @Test(timeout = 3000)
+    public void recursionSafetyCheck_rand() {
+        Random rand = new Random();
+        for (int i = 0; i < 100; i++) {
+            graph.add(String.valueOf(rand.nextInt(50)), String.valueOf(rand.nextInt(50)));
+        }
+        graph.add("a", "b");
+        graph.computeDependencies();
+        Assert.assertThat(dependencyOrder, CoreMatchers.hasItems("a", "b"));
+    }
+}


### PR DESCRIPTION
existing logic misfires if downstream node has the same count of comingOutNodes as its parent.
added actual depth check to see if:
\- there is cyclic dependency issue ahead
\- we made any progress after previous iteration of dependency graph calculation.