### PR TITLE
DAT-3423

### DIFF
--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -95,7 +95,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
 
         for (NamespaceDetails details : NamespaceDetailsFactory.getInstance().getNamespaceDetails()) {
             for (String namespace : details.getNamespaces()) {
-                if (details.supports(this, namespace)) {
+                if (details.getPriority() > 0 && details.supports(this, namespace)) {
                     String shortName = details.getShortName(namespace);
                     String url = details.getSchemaUrl(namespace);
                     if (shortName != null) {


### PR DESCRIPTION
- Save diffOutputCOntrol and externalFileDir for use by change generators that may need them
- Don't include 0-priority namespaces in generated XML
