### PR TITLE
Bringing in fixes from DAT-1999 bugfix branch

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/OfflineConnection.java
+++ b/liquibase-core/src/main/java/liquibase/database/OfflineConnection.java
@@ -273,7 +273,7 @@ public class OfflineConnection implements DatabaseConnection {
     }
 
     public void setConnectionUserName(String connectionUserName) {
-        this.connectionUserName = connectionUserName;
+        this.connectionUserName = StringUtils.isEmpty(connectionUserName) ? null : connectionUserName;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
@@ -157,7 +157,7 @@ public class MissingTableChangeGenerator extends AbstractChangeGenerator impleme
 
             ConstraintsConfig constraintsConfig = null;
             // In MySQL, the primary key must be specified at creation for an autoincrement column
-            if ((pkColumnList != null) && pkColumnList.contains(column.getName())) {
+            if (column.isAutoIncrement() && (pkColumnList != null) && pkColumnList.contains(column.getName())) {
                 if ((referenceDatabase instanceof MSSQLDatabase) && (primaryKey.getBackingIndex() != null) &&
                         (primaryKey.getBackingIndex().getClustered() != null) && !primaryKey.getBackingIndex()
                         .getClustered()) {
@@ -184,8 +184,12 @@ public class MissingTableChangeGenerator extends AbstractChangeGenerator impleme
                         constraintsConfig.setNullable(false);
                     }
                 }
-            } else if ((column.isNullable() != null) && !column.isNullable()) {
+            }
+
+            if ((column.isNullable() != null) && !column.isNullable()) {
+                if (constraintsConfig == null) {
                 constraintsConfig = new ConstraintsConfig();
+                }
                 constraintsConfig.setNullable(false);
                 if (!column.shouldValidateNullable()) {
                     constraintsConfig.setShouldValidateNullable(false);

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -130,6 +130,8 @@ public class Main {
     private Boolean managingLogConfig = null;
     private boolean outputsLogMessages = false;
     private String sqlFile;
+    protected String delimiter;
+    protected String rollbackScript;
 
     /**
      * Entry point. This is what gets executes when starting this program from the command line. This is actually
@@ -773,7 +775,8 @@ public class Main {
                         && !cmdParm.startsWith("--" + OPTIONS.INCLUDE_CATALOG)
                         && !cmdParm.startsWith("--" + OPTIONS.INCLUDE_TABLESPACE)
                         && !cmdParm.startsWith("--" + OPTIONS.SCHEMAS)
-                        && !cmdParm.startsWith("--" + OPTIONS.SNAPSHOT_FORMAT)) {
+                        && !cmdParm.startsWith("--" + OPTIONS.SNAPSHOT_FORMAT)
+                        && !cmdParm.startsWith("--" + OPTIONS.OUTPUT_SCHEMAS_AS)) {
                     messages.add(String.format(coreBundle.getString("unexpected.command.parameter"), cmdParm));
                 }
             }

--- a/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlSerializer.java
@@ -160,9 +160,6 @@ public abstract class YamlSerializer implements LiquibaseSerializer {
         json = json.replaceAll("!!timestamp \"([^\"]*)\"", "$1");
         json = json.replaceAll("!!float \"([^\"]*)\"", "$1");
         json = json.replaceAll("!!liquibase.[^\\s]+ (\"\\w+\")", "$1");
-        if (json.contains("!!")) {
-            throw new IllegalStateException(String.format("Serialize failed. Illegal char on %s position: %s", json.indexOf("!!"), json));
-        }
         return json;
     }
 

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
@@ -157,7 +157,15 @@ public class CreateProcedureGenerator extends AbstractSqlGenerator<CreateProcedu
                 next = clauseIterator.nextNonWhitespace();
             }
             if ((next != null) && clauseIterator.hasNext()) {
-                Object procNameClause = clauseIterator.nextNonWhitespace();
+
+                //sometimes people don't include a space before the function name, like `create procedure[test]`
+                boolean hasWhitespaceBeforeName = false;
+                Object procNameClause = clauseIterator.next();
+                if (procNameClause instanceof StringClauses.Whitespace || procNameClause instanceof StringClauses.Comment) {
+                    procNameClause = clauseIterator.nextNonWhitespace();
+                    hasWhitespaceBeforeName = true;
+                }
+
                 if (procNameClause instanceof String) {
                     String[] nameParts = ((String) procNameClause).split("\\.");
                     String finalName;
@@ -169,6 +177,9 @@ public class CreateProcedureGenerator extends AbstractSqlGenerator<CreateProcedu
                         finalName = nameParts[0] + "." + database.escapeObjectName(schemaName, Schema.class) + "." + nameParts[2];
                     } else {
                         finalName = (String) procNameClause; //just go with what was there
+                    }
+                    if (!hasWhitespaceBeforeName) {
+                        finalName = " " + finalName;
                     }
                     clauseIterator.replace(finalName);
                 }


### PR DESCRIPTION
Fixes bought in:
- DAT-3109 Issue with 'nullable' and 'constraint' sections in generated changelog
- DAT-3098 fixed issue with empty username in offline comparisons
- diffChangelog of an Oracle database does not include expected createIndex change
- Don't throw an exception if snapshot yaml contains `!!`
- Fixed CLI parsing error if using delimiter or rollbackScript or outputSchemaAs
- Handling adding schema when createProcedure doesn't have a whitespace before the object name