### PR TITLE
Fixed issue with default value for `Char` datatype (Oracle)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -631,6 +631,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
             Object columnDef = columnMetadataResultSet.get(COLUMN_DEF_COL);
             if ("CHAR".equalsIgnoreCase(columnInfo.getType().getTypeName()) && (columnDef instanceof String) && !
                 ((String) columnDef).startsWith("'") && !((String) columnDef).endsWith("'")) {
+                columnMetadataResultSet.set(COLUMN_DEF_COL, null);
                 return new DatabaseFunction((String) columnDef);
             }
 

--- a/liquibase-core/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Index.java
@@ -113,7 +113,7 @@ public class Index extends AbstractDatabaseObject {
     }
 
     public Index setColumns(List<Column> columns) {
-        if (getRelation() instanceof Table) {
+        if (getAttribute("relation", Object.class) instanceof Table) {
             for (Column column :columns) {
                 column.setRelation(getRelation());
             }

--- a/liquibase-core/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Index.java
@@ -113,7 +113,7 @@ public class Index extends AbstractDatabaseObject {
     }
 
     public Index setColumns(List<Column> columns) {
-        if (getAttribute("relation", Object.class) instanceof Table) {
+        if (getRelation() instanceof Table) {
             for (Column column :columns) {
                 column.setRelation(getRelation());
             }


### PR DESCRIPTION
If the column type is a CHAR and the column definition is a non-quoted string, then we need to set the COL_DEF_COL to null so that the generated column definition doesn't get treated as a computed value.