### PR TITLE
GenerateChangeLog should define primary keys separately when column o…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
@@ -22,14 +22,11 @@ import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.PrimaryKey;
 import liquibase.structure.core.Table;
-import liquibase.util.StringUtils;
 import liquibase.structure.core.UniqueConstraint;
+import liquibase.util.StringUtils;
 
 import java.math.BigInteger;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class MissingTableChangeGenerator extends AbstractChangeGenerator implements MissingObjectChangeGenerator {
 
@@ -155,9 +152,11 @@ public class MissingTableChangeGenerator extends AbstractChangeGenerator impleme
                 columnConfig.setAutoIncrement(true);
             }
 
+            boolean primaryKeyOrderMatchesTableOrder = checkPrimaryKeyOrderMatchesTableOrder(missingTable, pkColumnList);
+
             ConstraintsConfig constraintsConfig = null;
             // In MySQL, the primary key must be specified at creation for an autoincrement column
-            if ((pkColumnList != null) && pkColumnList.contains(column.getName())) {
+            if ((pkColumnList != null) && primaryKeyOrderMatchesTableOrder &&  pkColumnList.contains(column.getName())) {
                 if ((referenceDatabase instanceof MSSQLDatabase) && (primaryKey.getBackingIndex() != null) &&
                         (primaryKey.getBackingIndex().getClustered() != null) && !primaryKey.getBackingIndex()
                         .getClustered()) {
@@ -247,6 +246,29 @@ public class MissingTableChangeGenerator extends AbstractChangeGenerator impleme
         return new Change[]{
                 change
         };
+    }
+
+    private boolean checkPrimaryKeyOrderMatchesTableOrder(Table missingTable, List<String> pkColumnList) {
+        if (pkColumnList == null) {
+            return false;
+        }
+
+        int lastTableOrder = -1;
+        final List<Column> tableColumnList = missingTable.getColumns();
+
+        for (String pkColumnName : pkColumnList) {
+            for (int i = 0; i < tableColumnList.size(); i++) {
+                final Column tableColumn = tableColumnList.get(i);
+                if (Objects.equals(tableColumn.getName(), pkColumnName)) {
+                    if (i < lastTableOrder) {
+                        return false;
+                    }
+                    lastTableOrder = i;
+                }
+            }
+        }
+
+        return true;
     }
 
     private Map<Column, UniqueConstraint> getSingleColumnUniqueConstraints(Table missingTable) {


### PR DESCRIPTION
…rder doesn't match table column order

DAT-3532