### PR TITLE
DAT-3625: Fixed issue with generation `datetime` data type for column through `ColumnSnapshotGenerator` (MSSQL)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -90,7 +90,6 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
 
         // Information obtained from:
         // https://docs.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql
-        defaultDataTypeParameters.put("datetime", 3);
         defaultDataTypeParameters.put("datetime2", 7);
         defaultDataTypeParameters.put("datetimeoffset", 7);
         defaultDataTypeParameters.put("time", 7);

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -102,6 +102,8 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
         defaultDataTypeParameters.put("money", 4);
         defaultDataTypeParameters.put("smallmoney", 0);
 
+        unmodifiableDataTypes.add("datetime");
+
         addReservedWords(createReservedWordsCollection());
     }
 


### PR DESCRIPTION
Liquibase set column size to `datetime` data type through `ColumnSnapshotGenerator#readDataType(CachedRow columnMetadataResultSet, Column column, Database database)` method, which very incorrect according to SQLServer documentation, It was decided to add `datetime` to the list of `unmodifiableDataTypes` to prevent existing behaviour.