### PR TITLE
DAT-3636: updated query which retrieve information about sequence (Oracle)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -127,6 +127,8 @@ public abstract class AbstractJdbcDatabase implements Database {
     private Map<String, Object> attributes = new HashMap<>();
     protected String dbFullVersion;
 
+    protected Map<String, Object> sequenceDefaultValues = new HashMap<>();
+
     public String getName() {
         return toString();
     }
@@ -1645,4 +1647,17 @@ public abstract class AbstractJdbcDatabase implements Database {
     public CatalogAndSchema.CatalogAndSchemaCase getSchemaAndCatalogCase() {
         return CatalogAndSchema.CatalogAndSchemaCase.UPPER_CASE;
     }
+
+    @Override
+    public Object getDefaultValueForSequence(String attribute, Boolean max) {
+        if (max != null) {
+            if (max) {
+                attribute = attribute.concat("Max");
+            } else {
+                attribute = attribute.concat("Min");
+            }
+        }
+        return sequenceDefaultValues.getOrDefault(attribute, null);
+    }
+
 }

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -459,5 +459,14 @@ public interface Database extends PrioritizedService {
     String unescapeDataTypeString(String dataTypeString);
 
     ValidationErrors validate();
+
+    /**
+     * Returns default value for sequence attribute
+     * @param attribute attribute name
+     * @param max true if you need to get max value for a same attribute, false if min value, null if an attribute has single default value
+     * @return default value of attribute or null if database does not have defaults
+     */
+    Object getDefaultValueForSequence(String attribute, Boolean max);
+
 }
 

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -1,5 +1,6 @@
 package liquibase.database.core;
 
+import java.math.BigInteger;
 import liquibase.CatalogAndSchema;
 import liquibase.Scope;
 import liquibase.database.AbstractJdbcDatabase;
@@ -34,8 +35,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.util.ResourceBundle.getBundle;
-
 /**
  * Encapsulates Oracle database support.
  */
@@ -43,7 +42,6 @@ public class OracleDatabase extends AbstractJdbcDatabase {
     private static final Pattern PROXY_USER = Pattern.compile(".*(?:thin|oci)\\:(.+)/@.*");
 
     public static final String PRODUCT_NAME = "oracle";
-    private static ResourceBundle coreBundle = getBundle("liquibase/i18n/liquibase-core");
     protected final int SHORT_IDENTIFIERS_LENGTH = 30;
     protected final int LONG_IDENTIFIERS_LEGNTH = 128;
     public static final int ORACLE_12C_MAJOR_VERSION = 12;
@@ -74,6 +72,26 @@ public class OracleDatabase extends AbstractJdbcDatabase {
         super.sequenceNextValueFunction = "%s.nextval";
         //noinspection HardCodedStringLiteral
         super.sequenceCurrentValueFunction = "%s.currval";
+
+        super.sequenceDefaultValues = this.getDefaultValuesForSequence();
+    }
+
+    private Map<String, Object> getDefaultValuesForSequence() {
+        Map<String, Object> defaultValues = new HashMap<>();
+        //MIN_VALUE
+        defaultValues.put("minValueMax", BigInteger.ONE);
+        defaultValues.put("minValueMin", new BigInteger("-999999999999999999999999999"));
+        //MAX_VALUE
+        defaultValues.put("maxValueMax", new BigInteger("9999999999999999999999999999"));
+        //INCREMENT_BY
+        defaultValues.put("incrementBy", BigInteger.ONE);
+        //CYCLE
+        defaultValues.put("cycle", Boolean.FALSE);
+        //ORDERED
+        defaultValues.put("ordered", Boolean.FALSE);
+        //CACHE_SIZE
+        defaultValues.put("cacheSize", new BigInteger("20"));
+        return defaultValues;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
@@ -795,6 +795,11 @@ public class MockDatabase implements Database, InternalDatabase {
     }
 
     @Override
+    public Object getDefaultValueForSequence(String attribute, Boolean max) {
+        return null;
+    }
+
+    @Override
     public boolean supportsNotNullConstraintNames() {
         return false;
     }

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -191,7 +191,7 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
                     "     ELSE CASE WHEN min_value=(-999999999999999999999999999) THEN NULL else min_value END\n" +
                     "END AS min_value, \n" +
                     "CASE WHEN increment_by > 0 \n" +
-                    "     THEN CASE WHEN max_value=999999999999999999999999999 THEN NULL ELSE max_value END\n" +
+                    "     THEN CASE WHEN max_value=9999999999999999999999999999 THEN NULL ELSE max_value END\n" +
                     "     ELSE CASE WHEN max_value=last_number THEN NULL else max_value END \n" +
                     "END  AS max_value, \n" +
                     "CASE WHEN increment_by = 1 THEN NULL ELSE increment_by END AS increment_by, \n" +

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -7,6 +7,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.ExecutorService;
 import liquibase.logging.LogFactory;
+import liquibase.logging.LogService;
 import liquibase.logging.Logger;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
@@ -25,7 +26,17 @@ import java.util.Map;
  */
 public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
 
-    private Logger log = LogFactory.getInstance().getLog(SequenceSnapshotGenerator.class.getSimpleName());
+    private final Logger log = LogService.getLog(SequenceSnapshotGenerator.class);
+
+    private static final String SEQUENCE_NAME = "SEQUENCE_NAME";
+    private static final String START_VALUE = "START_VALUE";
+    private static final String MIN_VALUE = "MIN_VALUE";
+    private static final String MAX_VALUE = "MAX_VALUE";
+    private static final String CACHE_SIZE = "CACHE_SIZE";
+    private static final String INCREMENT_BY = "INCREMENT_BY";
+    private static final String WILL_CYCLE = "WILL_CYCLE";
+    private static final String IS_ORDERED = "IS_ORDERED";
+    private static final String SEQ_TYPE = "SEQ_TYPE";
 
     public SequenceSnapshotGenerator() {
         super(Sequence.class, new Class[]{Schema.class});
@@ -82,7 +93,7 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
 
     private DatabaseObject getSequences(DatabaseObject example, Database database, List<Map<String, ?>> sequences) {
         for (Map<String, ?> sequenceRow : sequences) {
-            String name = cleanNameFromDatabase((String) sequenceRow.get("SEQUENCE_NAME"), database);
+            String name = cleanNameFromDatabase((String) sequenceRow.get(SEQUENCE_NAME), database);
             if (((database.isCaseSensitive() && name.equals(example.getName())) || (!database.isCaseSensitive() &&
                 name.equalsIgnoreCase(example.getName())))) {
                 return mapToSequence(sequenceRow, example.getSchema(), database);
@@ -92,24 +103,24 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
     }
 
     private Sequence mapToSequence(Map<String, ?> sequenceRow, Schema schema, Database database) {
-        String name = cleanNameFromDatabase((String) sequenceRow.get("SEQUENCE_NAME"), database);
-        Sequence seq = new Sequence();
-        seq.setName(name);
-        seq.setSchema(schema);
-        seq.setStartValue(toBigInteger(sequenceRow.get("START_VALUE"), database));
-        seq.setMinValue(toBigInteger(sequenceRow.get("MIN_VALUE"), database));
-        seq.setMaxValue(toBigInteger(sequenceRow.get("MAX_VALUE"), database));
-        seq.setCacheSize(toBigInteger(sequenceRow.get("CACHE_SIZE"), database));
-        seq.setIncrementBy(toBigInteger(sequenceRow.get("INCREMENT_BY"), database));
-        seq.setWillCycle(toBoolean(sequenceRow.get("WILL_CYCLE"), database));
-        seq.setOrdered(toBoolean(sequenceRow.get("IS_ORDERED"), database));
-        seq.setDataType((String) sequenceRow.get("SEQ_TYPE"));
+        String name = cleanNameFromDatabase((String) sequenceRow.get(SEQUENCE_NAME), database);
+        Sequence seq = new Sequence()
+            .setName(name)
+            .setSchema(schema)
+            .setStartValue(toBigInteger(sequenceRow.get(START_VALUE)))
+            .setMinValue(toBigInteger(sequenceRow.get(MIN_VALUE)))
+            .setMaxValue(toBigInteger(sequenceRow.get(MAX_VALUE)))
+            .setCacheSize(toBigInteger(sequenceRow.get(CACHE_SIZE)))
+            .setIncrementBy(toBigInteger(sequenceRow.get(INCREMENT_BY)))
+            .setWillCycle(toBoolean(sequenceRow.get(WILL_CYCLE)))
+            .setOrdered(toBoolean(sequenceRow.get(IS_ORDERED)))
+            .setDataType((String) sequenceRow.get(SEQ_TYPE));
         seq.setAttribute(LIQUIBASE_COMPLETE, true);
 
         return seq;
     }
 
-    protected Boolean toBoolean(Object value, Database database) {
+    protected Boolean toBoolean(Object value) {
         if (value == null) {
             return null;
         }
@@ -131,7 +142,7 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
         }
     }
 
-    protected BigInteger toBigInteger(Object value, Database database) {
+    protected BigInteger toBigInteger(Object value) {
         if (value == null) {
             return null;
         }
@@ -177,29 +188,7 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
         } else if (database instanceof InformixDatabase) {
             return "SELECT tabname AS SEQUENCE_NAME FROM systables t, syssequences s WHERE s.tabid = t.tabid AND t.owner = '" + schema.getName() + "'";
         } else if (database instanceof OracleDatabase) {
-            /*
-             * Return an SQL statement that only returns the non-default values so the output changeLog is cleaner
-             * and less polluted with unnecessary values.
-             * The the following pages for the defaults (consistent for all supported releases ATM):
-             * 12cR2: http://docs.oracle.com/database/122/SQLRF/CREATE-SEQUENCE.htm
-             * 12cR1: http://docs.oracle.com/database/121/SQLRF/statements_6017.htm
-             * 11gR2: http://docs.oracle.com/cd/E11882_01/server.112/e41084/statements_6015.htm
-             */
-            return "SELECT sequence_name, \n" +
-                    "CASE WHEN increment_by > 0 \n" +
-                    "     THEN CASE WHEN min_value=1 THEN NULL ELSE min_value END\n" +
-                    "     ELSE CASE WHEN min_value=(-999999999999999999999999999) THEN NULL else min_value END\n" +
-                    "END AS min_value, \n" +
-                    "CASE WHEN increment_by > 0 \n" +
-                    "     THEN CASE WHEN max_value=9999999999999999999999999999 THEN NULL ELSE max_value END\n" +
-                    "     ELSE CASE WHEN max_value=last_number THEN NULL else max_value END \n" +
-                    "END  AS max_value, \n" +
-                    "CASE WHEN increment_by = 1 THEN NULL ELSE increment_by END AS increment_by, \n" +
-                    "CASE WHEN cycle_flag = 'N' THEN NULL ELSE cycle_flag END AS will_cycle, \n" +
-                    "CASE WHEN order_flag = 'N' THEN NULL ELSE order_flag END AS is_ordered, \n" +
-                    "LAST_NUMBER as START_VALUE, \n" +
-                    "CASE WHEN cache_size = 20 THEN NULL ELSE cache_size END AS cache_size \n" +
-                    "FROM ALL_SEQUENCES WHERE SEQUENCE_OWNER = '" + schema.getCatalogName() + "'";
+            return "SELECT SEQUENCE_NAME AS SEQUENCE_NAME, MIN_VALUE, MAX_VALUE, INCREMENT_BY, CYCLE_FLAG AS WILL_CYCLE, ORDER_FLAG AS IS_ORDERED, LAST_NUMBER as START_VALUE, CACHE_SIZE FROM ALL_SEQUENCES WHERE SEQUENCE_OWNER = '" + schema.getCatalogName() + "'";
         } else if (database instanceof PostgresDatabase) {
             int version = 9;
             try {


### PR DESCRIPTION
Previous state of query is incorrect because it checks for `maxValue` as `999999999999999999999999999` (27 symbols), but according to documentation this value is `99999999999999999999999999999` (28symbols).
https://docs.oracle.com/en/database/oracle/oracle-database/12.2/sqlrf/CREATE-SEQUENCE.html#GUID-E9C78A8C-615A-4757-B2A8-5E6EFB130571