### PR TITLE
DAT-3633: modified `setDefaultSchemaName` method for MSSQL 

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -1,5 +1,6 @@
 package liquibase.database.core;
 
+import java.sql.Connection;
 import liquibase.CatalogAndSchema;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.AbstractJdbcDatabase;
@@ -113,11 +114,15 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
 
     @Override
     public void setDefaultSchemaName(String schemaName) {
-        if (schemaName != null && !schemaName.equalsIgnoreCase(getConnectionSchemaName())) {
-            throw new RuntimeException(String.format(
-                "Cannot use default schema name %s on Microsoft SQL Server because the login " +
-                    "schema of the current user (%s) is different and MSSQL does not support " +
-                    "setting the default schema per session.", schemaName, getConnectionSchemaName()));
+        if(this.getConnection() instanceof OfflineConnection) {
+            //skip the check below, when working with offline connection
+        } else {
+            if (schemaName != null && !schemaName.equalsIgnoreCase(getConnectionSchemaName())) {
+                throw new RuntimeException(String.format(
+                        "Cannot use default schema name %s on Microsoft SQL Server because the login " +
+                                "schema of the current user (%s) is different and MSSQL does not support " +
+                                "setting the default schema per session.", schemaName, getConnectionSchemaName()));
+            }
         }
         super.setDefaultSchemaName(schemaName);
     }


### PR DESCRIPTION
Modified `setDefaultSchemaName` method for MSSQL to avoid runtime exception, when working with offline connection in multischema environment through `diff` or `diffChangeLog` workflow.