### PR TITLE
DAT-3639: added `java.util.Date` as known input for

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -458,6 +458,8 @@ public abstract class AbstractJdbcDatabase implements Database {
             return getTimeLiteral(((java.sql.Time) date));
         } else if (date instanceof java.sql.Timestamp) {
             return getDateTimeLiteral(((java.sql.Timestamp) date));
+        } else if(date instanceof java.util.Date) {
+            return getDateTimeLiteral(new java.sql.Timestamp(date.getTime()));
         } else {
             throw new RuntimeException("Unexpected type: " + date.getClass().getName());
         }


### PR DESCRIPTION
`AbstractJdbcDatabase#getDateLiteral(final Date date)`, it helps to avoid
runtime exception when liquibase updates with `yaml` format of changelog.