### PR TITLE
Liquibase 3.8.0 breaks embedded use cases with Java 9+

### DIFF
--- a/liquibase-core/src/main/java/liquibase/license/LicenseServiceFactory.java
+++ b/liquibase-core/src/main/java/liquibase/license/LicenseServiceFactory.java
@@ -39,7 +39,7 @@ public class LicenseServiceFactory {
             }
           }
         }
-        catch (InstantiationException | IllegalAccessException e) {
+        catch (Throwable e) {
           LOG.severe("Unable to instantiate LicenseService", e);
         }
       }


### PR DESCRIPTION
DAT-3785