### PR TITLE
Dat 8811 - Change seems not to be feasible due to project dependency and other considerations

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -480,6 +480,8 @@ public class ChangeSet implements Conditional, ChangeLogChild {
      *
      * @return should change set be marked as ran
      */
+    // important note ChangeExecListener contains all information about ChangeImpact in it's
+    // reference variable changeImpacts
     public ExecType execute(DatabaseChangeLog databaseChangeLog, ChangeExecListener listener, Database database) throws MigrationFailedException {
         if (validationFailed) {
             return ExecType.MARK_RAN;

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1271,10 +1271,12 @@ public abstract class AbstractJdbcDatabase implements Database {
     @Override
     public void executeStatements(final Change change, final DatabaseChangeLog changeLog, final List<SqlVisitor> sqlVisitors) throws LiquibaseException {
         SqlStatement[] statements = change.generateStatements(this);
-
+        change.getChangeSet().setAttribute()
         execute(statements, sqlVisitors);
     }
 
+    String SQL_RESULT_TEMPLATE = " %d \n  (1 row affected) \n";
+    StringBuilder commandOutputBuilder = new StringBuilder();
     /*
      * Executes the statements passed
      *
@@ -1291,6 +1293,14 @@ public abstract class AbstractJdbcDatabase implements Database {
             LogFactory.getLogger().debug("Executing Statement: " + statement);
             try {
                 ExecutorService.getInstance().getExecutor(this).execute(statement, sqlVisitors);
+                // setting value of executed to true to identify statements that got executed successfully
+                // again not that any value which causes an issue is identified by DatabaseException raised in
+                // ExecuteStatementCallback
+                if (statement instanceof RawSqlStatement) {
+                    String sql = ((RawSqlStatement) statement).getSql();
+                    String result = SQL_RESULT_TEMPLATE.format(sql);
+                    commandOutputBuilder.append(result);
+                }
             } catch (DatabaseException e) {
                 if (statement.continueOnError()) {
                     LogFactory.getLogger().severe("Error executing statement '"+statement.toString()+"', but continuing", e);

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1271,12 +1271,15 @@ public abstract class AbstractJdbcDatabase implements Database {
     @Override
     public void executeStatements(final Change change, final DatabaseChangeLog changeLog, final List<SqlVisitor> sqlVisitors) throws LiquibaseException {
         SqlStatement[] statements = change.generateStatements(this);
-        change.getChangeSet().setAttribute()
         execute(statements, sqlVisitors);
+        // NOT FEASIBLE AS SQLFileChangeAppDBA cannot be applied here
+        if (change instanceof SqlFileChangeAppDBA.class) {
+            for (SqlStatement statement : statements) {
+                
+            }
+        }
     }
 
-    String SQL_RESULT_TEMPLATE = " %d \n  (1 row affected) \n";
-    StringBuilder commandOutputBuilder = new StringBuilder();
     /*
      * Executes the statements passed
      *
@@ -1293,13 +1296,8 @@ public abstract class AbstractJdbcDatabase implements Database {
             LogFactory.getLogger().debug("Executing Statement: " + statement);
             try {
                 ExecutorService.getInstance().getExecutor(this).execute(statement, sqlVisitors);
-                // setting value of executed to true to identify statements that got executed successfully
-                // again not that any value which causes an issue is identified by DatabaseException raised in
-                // ExecuteStatementCallback
                 if (statement instanceof RawSqlStatement) {
-                    String sql = ((RawSqlStatement) statement).getSql();
-                    String result = SQL_RESULT_TEMPLATE.format(sql);
-                    commandOutputBuilder.append(result);
+                    buildProgrammaticOutput((RawSqlStatement) statement);
                 }
             } catch (DatabaseException e) {
                 if (statement.continueOnError()) {
@@ -1309,6 +1307,18 @@ public abstract class AbstractJdbcDatabase implements Database {
                 }
             }
         }
+    }
+
+    /**
+     * Datical Generated query ran successfully output
+     * for user to identify which query ran in deployReport.html
+     * @param rawSqlStatement
+     */
+    public void buildProgrammaticOutput(RawSqlStatement rawSqlStatement) {
+        String sql = rawSqlStatement.getSql();
+        String rowsAffected = "(1 rows affected)";
+        String finalResult = String.format("%s \n %s", sql, rowsAffected);
+        rawSqlStatement.setOutputResult(finalResult);
     }
 
 

--- a/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
@@ -399,8 +399,10 @@ public class JdbcExecutor extends AbstractExecutor {
                     stmt.setEscapeProcessing(false);
                 }
                 try {
+                    // if this executes successfully then we don't need any value to check  that it was a success.
+                    // if it isn't a success then it will cause an exception
                     stmt.execute(statement);
-                } catch (Throwable e) {
+                } catch (SQLException e) {
                     throw new DatabaseException(e.getMessage()+ " [Failed SQL: "+statement+"]", e);
                 }
             }

--- a/liquibase-core/src/main/java/liquibase/statement/core/RawSqlStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/RawSqlStatement.java
@@ -6,7 +6,7 @@ public class RawSqlStatement extends AbstractSqlStatement {
 
     private String sql;
     private String endDelimiter  = ";";
-    private boolean isExecuted;
+    private String outputResult;
 
 
     public RawSqlStatement(String sql) {
@@ -40,4 +40,13 @@ public class RawSqlStatement extends AbstractSqlStatement {
     public String toString() {
         return sql;
     }
+
+    public String getOutputResult() {
+        return outputResult;
+    }
+
+    public void setOutputResult(String executionResult) {
+        this.outputResult = executionResult;
+    }
+
 }

--- a/liquibase-core/src/main/java/liquibase/statement/core/RawSqlStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/RawSqlStatement.java
@@ -6,6 +6,7 @@ public class RawSqlStatement extends AbstractSqlStatement {
 
     private String sql;
     private String endDelimiter  = ";";
+    private boolean isExecuted;
 
 
     public RawSqlStatement(String sql) {
@@ -25,6 +26,14 @@ public class RawSqlStatement extends AbstractSqlStatement {
 
     public String getEndDelimiter() {
         return endDelimiter.replace("\\r","\r").replace("\\n","\n");
+    }
+
+    public boolean isExecuted() {
+        return isExecuted;
+    }
+
+    public void setExecuted(boolean isExecuted) {
+        this.isExecuted = isExecuted;
     }
 
     @Override


### PR DESCRIPTION
@achehrynets Upon further looking into this issue, DAT-5695 is not a feasible fix. 

The programmatic way to add row count information to the Report is by indentifying which sql statement got executed and then putting this into the specific Change (for SqlFile it would be SqlFileChangeAppDBA), using the stored output result in this change, and then build a ChangeImpact out of the Change. 

However, for this to be done, we need to identify which Change we are using in AbstractJdbcDatabase, which is a Liquibase class file. Liquibase project cannot identify this class since it doesn't have dependency on appDba which is where SqlFileChangeAppDBA class is. Other way is by making changes to Change.java itself which would result in changes to apis of all child classes of Change.java, without any use, which I don't think is good. 

In addition to this, there are other considerations too that I thought about such as having extremely large number of sqls. In this scenario the programmatic fix could lead to performance impact since we need to initially create the output for Each SqlStatement in code and only later add to a spool file. 

Furthermore, I also looked into the typical flow of how SqlPlusChange SqlCmdChange processes it's result and why we see the (1 rows affected). These changes are done by the ChangeSet which calls a external process using ProcessBuilder to execute sqlplus.exe (if oracle) likewise for other DBs and appends their output to a spoolfile. 

Our Programatic flow would be completely different. Running each statement 1 by 1 using jdbc, adding the resultant output to Change and then going back to Changeset (and adding it to spoolFile) and finally in ChangeImpact. By the time we have made added the output to Change, it is likely that we will already have seen performance impacts if we have a lot of Sql in the file. In addition, the design of CommandGenerator, ExecShellCommandChange doesn't fit the flow. 

Owing to these considerations, I feel like there might not be a feasible fix.