### PR TITLE
[DAT-15843] Do not strip [/] from Oracle SQL statement at the end if there is an [*] before it

### DIFF
--- a/liquibase-core/src/main/java/liquibase/executor/LoggingExecutor.java
+++ b/liquibase-core/src/main/java/liquibase/executor/LoggingExecutor.java
@@ -105,8 +105,8 @@ public class LoggingExecutor extends AbstractExecutor {
                 }
 
                 if (database instanceof OracleDatabase) { //remove trailing /
-                    while (statement.matches("(?s).*[\\s\\r\\n]*/[\\s\\r\\n]*$")) { //all trailing /'s
-                        statement = statement.replaceFirst("[\\s\\r\\n]*/[\\s\\r\\n]*$", "");
+                    while (statement.matches("(?s).*[\\s\\r\\n]*[^*]/[\\s\\r\\n]*$")) { //all trailing /'s
+                        statement = statement.replaceFirst("[\\s\\r\\n]*[^*]/[\\s\\r\\n]*$", "");
                     }
                 }
 

--- a/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
@@ -391,8 +391,8 @@ public class JdbcExecutor extends AbstractExecutor {
             Integer updateCount = null;
             for (String statement : applyVisitors(sql, sqlVisitors)) {
                 if (database instanceof OracleDatabase) {
-                    while (statement.matches("(?s).*[\\s\\r\\n]*/[\\s\\r\\n]*$")) { //all trailing /'s
-                        statement = statement.replaceFirst("[\\s\\r\\n]*/[\\s\\r\\n]*$", "");
+                    while (statement.matches("(?s).*[\\s\\r\\n]*[^*]/[\\s\\r\\n]*$")) { //all trailing /'s
+                        statement = statement.replaceFirst("[\\s\\r\\n]*[^*]/[\\s\\r\\n]*$", "");
                     }
                 }
 


### PR DESCRIPTION
Main reason to do it that if the last statement is a multiline comment - when we strip the last slash, we get an error