### PR TITLE
Fossa Report: DAT-18919

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -4,7 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       distinct_id:
-
+      # Tag to use from :https://github.com/Datical/DaticalDB-installer/tags. Have this variable to be near an DaticalDb-installer version variable which is used during its report generation
+      # https://datical.atlassian.net/browse/DAT-18632
+      version_number_for_report_generation:
+        description: 'Typically supply the DaticalDb-installer version variable which is used during its report generation to be stored in the s3 bucket. eg 8.7.352'
+        required: true
+        
 jobs:
   fossa-scan:
     uses: liquibase/build-logic/.github/workflows/fossa.yml@main

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       distinct_id:
-      # Tag to use from :https://github.com/Datical/DaticalDB-installer/tags. Have this variable to be near an DaticalDb-installer version variable which is used during its report generation
+      # Tag to use from :https://github.com/Datical/DaticalDB-installer/tags. Have this variable to be near a DaticalDb-installer version variable which is used during its report generation
       # https://datical.atlassian.net/browse/DAT-18632
       version_number_for_report_generation:
         description: 'Typically supply the DaticalDb-installer version variable which is used during its report generation to be stored in the s3 bucket. eg 8.7.352'

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -13,7 +13,7 @@ on:
         
 jobs:
   fossa-scan:
-    uses: liquibase/build-logic/.github/workflows/fossa.yml@DAT-18919
+    uses: liquibase/build-logic/.github/workflows/fossa.yml@main
     secrets: inherit
     with:
       org: Datical

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   fossa-scan:
-    uses: liquibase/build-logic/.github/workflows/fossa.yml@main
+    uses: liquibase/build-logic/.github/workflows/fossa.yml@DAT-18919
     secrets: inherit
     with:
       org: Datical

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -13,7 +13,7 @@ on:
         
 jobs:
   fossa-scan:
-    uses: liquibase/build-logic/.github/workflows/fossa.yml@main
+    uses: liquibase/build-logic/.github/workflows/fossa.yml@DAT-18919
     secrets: inherit
     with:
       org: Datical

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   fossa-scan:
-    uses: liquibase/build-logic/.github/workflows/generate-upload-fossa-report.yml@main
+    uses: liquibase/build-logic/.github/workflows/generate-upload-fossa-report.yml@DAT-18919
     secrets: inherit
     with:
       version_number_for_report_generation: "${{ github.event.inputs.version_number_for_report_generation }}"

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -3,6 +3,7 @@ name: Fossa Report Generation
 on:
   workflow_dispatch:
     inputs:
+      # The distinct_id is required for Datical/liquibase to know if the job was completed successfully. https://github.com/Codex-/return-dispatch/blob/main/README.md?plain=1#L36
       distinct_id:
       # Tag to use from :https://github.com/Datical/DaticalDB-installer/tags. Have this variable to be near a DaticalDb-installer version variable which is used during its report generation
       # https://datical.atlassian.net/browse/DAT-18632

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,19 +5,13 @@ on:
     inputs:
       # The distinct_id is required for Datical/liquibase to know if the job was completed successfully. https://github.com/Codex-/return-dispatch/blob/main/README.md?plain=1#L36
       distinct_id:
-      # Tag to use from :https://github.com/Datical/DaticalDB-installer/tags. Have this variable to be near a DaticalDb-installer version variable which is used during its report generation
-      # https://datical.atlassian.net/browse/DAT-18632
-      version_number_for_report_generation:
-        description: 'Typically supply the DaticalDb-installer version variable which is used during its report generation to be stored in the s3 bucket. eg 8.7.352'
-        required: true
-        
+
 jobs:
   fossa-scan:
     uses: liquibase/build-logic/.github/workflows/fossa.yml@main
     secrets: inherit
     with:
       org: Datical
-      version_number_for_report_generation: ${{ github.event.inputs.version_number_for_report_generation }}
 
   # https://github.com/Codex-/return-dispatch/blob/main/README.md?plain=1#L35
   display-distinct-id:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -17,6 +17,7 @@ jobs:
     secrets: inherit
     with:
       org: Datical
+      version_number_for_report_generation: ${{ github.event.inputs.version_number_for_report_generation }}
 
   # https://github.com/Codex-/return-dispatch/blob/main/README.md?plain=1#L35
   display-distinct-id:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -8,10 +8,8 @@ on:
 
 jobs:
   fossa-scan:
-    uses: liquibase/build-logic/.github/workflows/fossa.yml@DAT-18919
+    uses: liquibase/build-logic/.github/workflows/generate-upload-fossa-report.yml@DAT-18919
     secrets: inherit
-    with:
-      org: Datical
 
   # https://github.com/Codex-/return-dispatch/blob/main/README.md?plain=1#L35
   display-distinct-id:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,11 +5,17 @@ on:
     inputs:
       # The distinct_id is required for Datical/liquibase to know if the job was completed successfully. https://github.com/Codex-/return-dispatch/blob/main/README.md?plain=1#L36
       distinct_id:
+      version_number_for_report_generation:
+        description: "Version number for report generation"
+        required: true
+        type: string
 
 jobs:
   fossa-scan:
     uses: liquibase/build-logic/.github/workflows/generate-upload-fossa-report.yml@DAT-18919
     secrets: inherit
+    with:
+      version_number_for_report_generation: ${{ github.event.inputs.version_number_for_report_generation }}
 
   # https://github.com/Codex-/return-dispatch/blob/main/README.md?plain=1#L35
   display-distinct-id:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,7 +15,7 @@ jobs:
     uses: liquibase/build-logic/.github/workflows/generate-upload-fossa-report.yml@DAT-18919
     secrets: inherit
     with:
-      version_number_for_report_generation: ${{ github.event.inputs.version_number_for_report_generation }}
+      version_number_for_report_generation: "${{ github.event.inputs.version_number_for_report_generation }}"
 
   # https://github.com/Codex-/return-dispatch/blob/main/README.md?plain=1#L35
   display-distinct-id:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   fossa-scan:
-    uses: liquibase/build-logic/.github/workflows/generate-upload-fossa-report.yml@DAT-18919
+    uses: liquibase/build-logic/.github/workflows/generate-upload-fossa-report.yml@main
     secrets: inherit
     with:
       version_number_for_report_generation: "${{ github.event.inputs.version_number_for_report_generation }}"


### PR DESCRIPTION
This pull request updates the Fossa report generation workflow to include a new input parameter and modify the job configuration. The most important changes include adding a version number input and updating the job to use a different workflow file.

Updates to Fossa report generation workflow:

* Added `version_number_for_report_generation` input parameter with a description and required status in `.github/workflows/fossa.yml`.
* Changed the job configuration to use `generate-upload-fossa-report.yml` instead of `fossa.yml` and included the new version number input.