### PR TITLE
🔧 Upgrade upload-artifact @v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,5 +90,5 @@ jobs:
     - name: Upload Security Report
       uses: actions/upload-artifact@v4
       with:
-        name: security-report
+        name: security-report-${{matrix.language}}
         path: ./reports/summary.pdf

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,7 +88,7 @@ jobs:
         outputDir: ./reports/
 
     - name: Upload Security Report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: security-report
         path: ./reports/summary.pdf


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow configuration to ensure compatibility with the latest version of the `upload-artifact` action.

Workflow configuration update:

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L91-R91): Updated the `upload-artifact` action from version `v3` to `v4` to leverage the latest features and improvements.