### PR TITLE
[DAT-21759] Fix CodeQL workflow security report timeout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,6 +82,7 @@ jobs:
         category: "/language:${{matrix.language}}"
 
     - name: Generate Security Report
+      continue-on-error: true
       uses: rsdmike/github-security-report-action@v3.0.4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to security report step to prevent timeout failures from breaking the workflow

## Root Cause Addressed

The "Generate Security Report" step (using `rsdmike/github-security-report-action@v3.0.4`) can timeout. Added `continue-on-error: true` so this doesn't fail the overall CodeQL workflow.

**Note**: This repo uses CodeQL autobuild, so it doesn't require the explicit Java 21 toolchain setup that other repos need. If the Java build fails due to toolchain requirements in the DAT-17807 branch, a separate fix will be needed.

## Test plan
- [ ] Verify CodeQL workflow triggers on this PR
- [ ] Verify CodeQL analysis completes successfully
- [ ] Verify security report timeout doesn't fail the overall job

🤖 Generated with [Claude Code](https://claude.com/claude-code)