### PR TITLE
[DAT-21970] Fix flawed MSSQL JDBC driver version check in FK snapshot logic

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ForeignKeySnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ForeignKeySnapshotGenerator.java
@@ -279,7 +279,7 @@ public class ForeignKeySnapshotGenerator extends JdbcSnapshotGenerator {
                 return false;
             }
 
-            if (driverMajorVersion >= 6 && driverMinorVersion >= 3) {
+            if (driverMajorVersion > 6 || (driverMajorVersion == 6 && driverMinorVersion >= 3)) {
                 return false;
             }
 


### PR DESCRIPTION
The driverUsesSpFkeys() method in ForeignKeySnapshotGenerator had a flawed semver comparison that caused FK referential action rules (ON DELETE/ON UPDATE) to be misread after upgrading the MSSQL JDBC driver from 12.4.0 to 13.2.1 (driver package 1.0.66 → 1.0.72).

Root cause:
The old condition `driverMajorVersion >= 6 && driverMinorVersion >= 3` incorrectly evaluates for any driver with major > 6 but minor < 3. For driver 13.2.1: `13 >= 6 && 2 >= 3` → false, causing the method to wrongly return true (thinks driver uses sp_fkeys convention).

This meant when the fastFetch() path called JDBC getImportedKeys(), the returned standard JDBC constant 3 (importedKeyNoAction) was interpreted using sp_fkeys convention where 3 = importedKeySetDefault. Meanwhile the bulkFetch() path used Liquibase's custom MSSQL SQL (ObjectProperty/CnstIsDeleteCascade) which only returns 0 or 1, accidentally producing the correct result.

The mismatch between these two paths caused diff to report phantom FK changes (e.g. "deleteRule changed from importedKeyNoAction to importedKeySetDefault") even when both databases had identical NO ACTION rules, resulting in non-empty diffChangeLogs.

Observed failure: Liquibase-CLI-testing repo,
customer_schema_mssql_phytelmaster.feature:113 expected an empty diffChangeLog but got changesets dropping and recreating FK PopulationRuleCodeSet_PopulationRuleCodeSetConfiguration_FK1.

Fix: Change the version comparison to properly handle semver: `driverMajorVersion > 6 || (driverMajorVersion == 6 && driverMinorVersion >= 3)`