### PR TITLE
Pin build-logic workflow refs to commit SHA

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   claude-review:
-    uses: liquibase/build-logic/.github/workflows/claude-code-review.yml@main
+    uses: liquibase/build-logic/.github/workflows/claude-code-review.yml@3bc448f805496d87c284977b62cda22c5aad540d # main
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,5 +26,5 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    uses: liquibase/build-logic/.github/workflows/claude.yml@main
+    uses: liquibase/build-logic/.github/workflows/claude.yml@3bc448f805496d87c284977b62cda22c5aad540d # main
     secrets: inherit

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   fossa-scan:
-    uses: liquibase/build-logic/.github/workflows/generate-upload-enterprise-3p-fossa-report.yml@main
+    uses: liquibase/build-logic/.github/workflows/generate-upload-enterprise-3p-fossa-report.yml@3bc448f805496d87c284977b62cda22c5aad540d # main
     secrets: inherit
     with:
       version_number_for_3p_fossa_report_generation: "${{ github.event.inputs.version_number_for_3p_fossa_report_generation }}"


### PR DESCRIPTION
## Summary
- Pin `liquibase/build-logic` reusable workflow refs from `@main` to a commit SHA
- Prevents supply chain attacks if `build-logic/main` branch is compromised

## Test plan
- [ ] Verify workflows still trigger correctly (the SHA points to the same commit as `main`)

DAT-22394